### PR TITLE
Change default RSI overbought/oversold thresholds to 70/30 respectively

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -196,8 +196,8 @@ export const configDefault:ChartsConfig = {
           hideRightAxis: true,
           brushed: true,
           crossHair: true,
-          overbought: 90,
-          oversold: 10,
+          overbought: 70,
+          oversold: 30,
         },
         stochastic: {
           hide: true,


### PR DESCRIPTION
I noticed that the overbought and oversold thresholds are rendered at 90 and 10 by default, despite the settings page showing 70/30. I think this change to the default chart config should fix that.


![image](https://github.com/user-attachments/assets/71fe6b4f-42cb-4dc5-9e41-b5536b0fd590)
